### PR TITLE
docs: document and add tests for existing behavior for monotonic and simplify logic for readability #23

### DIFF
--- a/src/ulid.ts
+++ b/src/ulid.ts
@@ -146,14 +146,17 @@ export const ulidFactory = (args?: ULIDFactoryArgs): ULIDFactory => {
                 let timestampOrNow: number = timestamp || Date.now();
                 validateTimestamp(timestampOrNow);
 
-                if (timestampOrNow <= lastTime) {
-                    const incrementedRandom = (lastRandom = incrementBase32(lastRandom));
-                    return encodeTime(lastTime, TIME_LEN) + incrementedRandom;
+                if (timestampOrNow > lastTime) {
+                    lastTime = timestampOrNow;
+                    const random = encodeRandom(RANDOM_LEN);
+                    lastRandom = random;
+                    return encodeTime(timestampOrNow, TIME_LEN) + random;
+                } else {
+                    // <= lastTime : increment lastRandom
+                    const random = incrementBase32(lastRandom);
+                    lastRandom = random;
+                    return encodeTime(lastTime, TIME_LEN) + random;
                 }
-
-                lastTime = timestampOrNow;
-                const newRandom = (lastRandom = encodeRandom(RANDOM_LEN));
-                return encodeTime(timestampOrNow, TIME_LEN) + newRandom;
             };
         })();
     } else {

--- a/test/ulid.spec.ts
+++ b/test/ulid.spec.ts
@@ -242,7 +242,7 @@ describe("ulid", function () {
             expect(ulid()).to.have.a.lengthOf(26);
         });
 
-        describe("with seedTime", function () {
+        describe("with seedTime should never step backwards in lexical sort", function () {
             before(function () {
                 this.ulid = ulidFactory({ monotonic: true });
             });
@@ -251,16 +251,16 @@ describe("ulid", function () {
                 expect(this.ulid(164436145)).to.equal("00004WT65H0000000000000000");
             });
 
-            it("second call", function () {
-                expect(this.ulid(164436145)).to.equal("00004WT65H0000000000000001");
+            it("second call with older timestamp returns current timestamp and incremented random", function () {
+                expect(this.ulid(164436145 - 1000)).to.equal("00004WT65H0000000000000001"); // the value of the ULIDs time component was not pushed backwards
             });
 
             it("third call", function () {
                 expect(this.ulid(164436145)).to.equal("00004WT65H0000000000000002");
             });
 
-            it("fourth call", function () {
-                expect(this.ulid(164436145)).to.equal("00004WT65H0000000000000003");
+            it("fourth call with even older timestamp returns current timestamp and incremented random", function () {
+                expect(this.ulid(164436145 - 86400)).to.equal("00004WT65H0000000000000003"); // the value of the ULIDs time component was not pushed backwards
             });
 
             describe("should throw an error", function () {


### PR DESCRIPTION
Some of these behaviors, passed down from the reference implementation, can be surprising and should be documented and demonstrated in the tests.