### PR TITLE
Export encodeTime to allow encoding of a MAX token when querying a list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { ulidFactory, decodeTime } from "./ulid";
+export { decodeTime, encodeTime, ulidFactory } from "./ulid";
 export type { ULID, ULIDFactory, ULIDFactoryArgs } from "./ulid";

--- a/src/ulid.ts
+++ b/src/ulid.ts
@@ -47,7 +47,7 @@ function validateTimestamp(timestamp: number): void {
     }
 }
 
-function encodeTime(timestamp: number): string {
+export function encodeTime(timestamp: number): string {
     validateTimestamp(timestamp);
 
     let mod: number;
@@ -182,7 +182,6 @@ export const ulidFactory = (args?: ULIDFactoryArgs): ULIDFactory => {
 // Don't publicly export private functions, but allow them to be tested.
 export const exportedForTesting = {
     encodeRandom,
-    encodeTime,
     incrementBase32,
     randomChar,
     replaceCharAt,

--- a/test/ulid.spec.ts
+++ b/test/ulid.spec.ts
@@ -3,10 +3,10 @@ const nodeCrypto = require("crypto");
 const sinon = require("sinon");
 
 import { expect } from "chai";
-import { decodeTime, ulidFactory } from "../src/index";
+import { decodeTime, encodeTime, ulidFactory } from "../src/index";
 import { exportedForTesting } from "../src/ulid";
 
-const { encodeRandom, encodeTime, incrementBase32, randomChar, validateTimestamp, webCryptoPRNG } =
+const { encodeRandom, incrementBase32, randomChar, validateTimestamp, webCryptoPRNG } =
     exportedForTesting;
 
 const TIME_LEN = 10;


### PR DESCRIPTION
When you want to query a list of items in a Durable Object you need to create a token for the MAX value.

Such as:
``` typescript
const encodedNow = encodeTime(Date.now())
    const taskList = await this.storage.list<AllTasks>({
      prefix: '$$_tasks::',
      end: `$$_tasks::${encodedNow}}`,
    })
 ```